### PR TITLE
feat: Implement Enhanced Details View for password entries

### DIFF
--- a/data/secrets.ui
+++ b/data/secrets.ui
@@ -111,28 +111,119 @@
                             <property name="margin-end">12</property>
                             <property name="spacing">12</property>
                             <child>
-                              <object class="GtkLabel" id="selected_password_label">
-                                <property name="label">Password Name Here</property>
-                                <property name="halign">start</property>
-                                <style><class name="title-4"/></style>
+                              <object class="AdwActionRow" id="path_row">
+                                <property name="title" translatable="yes">Path</property>
+                                <!-- Subtitle will be set programmatically with the path -->
                               </object>
                             </child>
                             <child>
-                              <object class="GtkBox" id="password_actions_box">
-                                <property name="orientation">horizontal</property>
-                                <property name="spacing">6</property>
-                                <property name="halign">start</property>
-                                <child>
-                                  <object class="GtkButton" id="copy_password_button">
-                                    <property name="label" translatable="yes">_Copy Password</property>
-                                    <property name="use-underline">true</property>
+                              <object class="AdwExpanderRow" id="password_expander_row">
+                                <property name="title" translatable="yes">Password</property>
+                                <property name="subtitle">Hidden</property> <!-- Or show asterisks -->
+                                <property name="enable-expansion">false</property> <!-- Not using AdwExpanderRow's expansion for this -->
+                                <property name="show-enable-switch">false</property> <!-- Not a switchable row -->
+                                <child> <!-- Use 'row' for single Gtk.Widget or 'header-suffix' for Gtk.Box -->
+                                    <object class="GtkBox">
+                                        <property name="orientation">horizontal</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                            <object class="GtkLabel" id="password_display_label">
+                                                <property name="label">●●●●●●●●</property> <!-- Placeholder -->
+                                                <property name="selectable">true</property>
+                                                <property name="ellipsize">end</property>
+                                            </object>
+                                        </child>
+                                        <child>
+                                            <object class="GtkToggleButton" id="show_hide_password_button">
+                                                <property name="icon-name">view-reveal-symbolic</property>
+                                                <property name="tooltip-text" translatable="yes">Show/Hide Password</property>
+                                                <property name="valign">center</property>
+                                            </object>
+                                        </child>
+                                    </object>
+                                </child>
+                                <property name="activatable-widget"> <!-- Make copy_password_button the activatable widget -->
+                                    <object class="GtkButton" id="copy_password_button_in_row"> <!-- New ID to avoid conflict if old one is just hidden -->
+                                        <property name="icon-name">edit-copy-symbolic</property>
+                                        <property name="tooltip-text" translatable="yes">Copy Password</property>
+                                        <property name="valign">center</property>
+                                        <style><class name="flat"/></style>
+                                    </object>
+                                </property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwActionRow" id="username_row">
+                                <property name="title" translatable="yes">Username</property>
+                                <!-- Subtitle (username) will be set programmatically -->
+                                <!-- No activatable widget by default, add button as suffix -->
+                                <child type="suffix">
+                                  <object class="GtkButton" id="copy_username_button">
                                     <property name="icon-name">edit-copy-symbolic</property>
-                                    <property name="sensitive">false</property> <!-- Initially -->
-                                    <style><class name="suggested-action"/></style>
+                                    <property name="tooltip-text" translatable="yes">Copy Username</property>
+                                    <property name="valign">center</property>
+                                    <style><class name="flat"/></style>
                                   </object>
                                 </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="AdwActionRow" id="url_row">
+                                <property name="title" translatable="yes">URL</property>
+                                <!-- Subtitle (URL) will be set programmatically -->
+                                <child type="suffix">
+                                  <object class="GtkButton" id="open_url_button">
+                                    <property name="icon-name">network-transmit-receive-symbolic</property> <!-- Or 'emblem-shared-symbolic' or 'mail-forward-symbolic' -->
+                                    <property name="tooltip-text" translatable="yes">Open URL</property>
+                                    <property name="valign">center</property>
+                                    <style><class name="flat"/></style>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                                <object class="AdwPreferencesGroup" id="notes_group">
+                                    <property name="title" translatable="yes">Notes</property>
+                                    <property name="margin-top">6</property> <!-- Add some space above notes -->
+                                    <child> <!-- AdwPreferencesGroup needs a child that can hold the textview -->
+                                        <object class="AdwClamp"> <!-- Use AdwClamp to constrain width -->
+                                            <property name="maximum-size">400</property> <!-- Adjust as needed -->
+                                             <child>
+                                                <object class="GtkScrolledWindow" id="notes_scrolled_window">
+                                                    <property name="hscrollbar-policy">never</property>
+                                                    <property name="vscrollbar-policy">automatic</property>
+                                                    <property name="min-content-height">100</property>
+                                                    <property name="vexpand">true</property> <!-- Allow notes to take remaining space -->
+                                                    <child>
+                                                        <object class="GtkLabel" id="notes_display_label">
+                                                            <property name="wrap">true</property>
+                                                            <property name="selectable">true</property>
+                                                            <property name="xalign">0</property> <!-- Align text to left -->
+                                                            <property name="valign">start</property>
+                                                            <property name="css-classes"> <!-- For theming if needed -->
+                                                                <list><string>dim-label</string></list>
+                                                            </property>
+                                                        </object>
+                                                    </child>
+                                                </object>
+                                            </child>
+                                        </object>
+                                    </child>
+                                </object>
+                            </child>
+                            <!-- Action buttons (Edit, Remove, Move/Rename) are still needed -->
+                            <child>
+                              <object class="GtkBox" id="password_actions_box"> <!-- This box was defined before -->
+                                <property name="orientation">horizontal</property>
+                                <property name="spacing">6</property>
+                                <property name="halign">start</property> <!-- Or center/end -->
+                                <property name="margin-top">12</property>
+                                <!-- copy_password_button is now part of AdwExpanderRow for Password -->
+                                <!-- <child>
+                                  <object class="GtkButton" id="copy_password_button">...</object>
+                                </child> -->
                                 <child>
-                                  <object class="GtkButton" id="edit_button"> <!-- Placeholder for Edit -->
+                                  <object class="GtkButton" id="edit_button">
                                     <property name="label" translatable="yes">_Edit</property>
                                     <property name="use-underline">true</property>
                                     <property name="icon-name">document-edit-symbolic</property>
@@ -143,16 +234,16 @@
                                   <object class="GtkButton" id="move_rename_button">
                                     <property name="label" translatable="yes">Mo_ve/Rename</property>
                                     <property name="use-underline">true</property>
-                                    <property name="icon-name">document-properties-symbolic</property> <!-- Or a more fitting icon -->
-                                    <property name="sensitive">false</property> <!-- Initially -->
+                                    <property name="icon-name">document-properties-symbolic</property>
+                                    <property name="sensitive">false</property>
                                   </object>
                                 </child>
                                 <child>
                                   <object class="GtkButton" id="remove_button">
                                     <property name="label" translatable="yes">_Remove</property>
                                     <property name="use-underline">true</property>
-                                    <property name="icon-name">edit-delete-symbolic</property> <!-- Or list-remove-symbolic -->
-                                    <property name="sensitive">false</property> <!-- Initially -->
+                                    <property name="icon-name">edit-delete-symbolic</property>
+                                    <property name="sensitive">false</property>
                                     <style><class name="destructive-action"/></style>
                                   </object>
                                 </child>


### PR DESCRIPTION
This commit significantly enhances the display of selected password entries:

1.  **PasswordStore Enhancement:**
    - Added `get_parsed_password_details(path)` to `PasswordStore`.
    - This method parses the decrypted password file content to extract the password (first line), username (from lines like `login:` or `user:`), URL, and any remaining lines as notes.

2.  **UI Update (`data/secrets.ui`):**
    - The right-hand details panel (`details_page_box`) has been redesigned.
    - It now uses `AdwActionRow` and `AdwExpanderRow` to display:
        - Path (read-only).
        - Password (initially hidden, with a Show/Hide toggle button and a Copy Password button). - Username (with a Copy Username button). - URL (with an Open URL button). - Notes (in a scrollable label).
    - The existing Edit, Move/Rename, and Remove buttons are preserved.

3.  **SecretsWindow Logic Update (`secrets/window.py`):**
    - Added new `Gtk.Template.Child` definitions for the enhanced UI elements.
    - When a password file is selected in the TreeView:
        - `get_parsed_password_details()` is called.
        - The new UI fields are populated with the parsed data. - Sensitivity of new action buttons (Show/Hide Password, Copy Username, Open URL) is managed based on data availability.
    - Implemented signal handlers for: - Toggling password visibility. - Copying the username to the clipboard. - Opening the URL using `Gtk.show_uri()`.
    - The main Copy Password button continues to function, now using the displayed password.

This provides you with a much richer and more interactive way to view the details of your password entries.