### PR TITLE
fix: Modify meson.build to resolve unknown language error

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,4 @@
-project('secrets', 'python',
-  version : '0.1.0',
+project('secrets', version : '0.1.0',
   meson_version : '>= 0.59.0',
   default_options : ['warning_level=2', 'werror=false'])
 


### PR DESCRIPTION
Removes 'python' as an explicit language in the main `project()` declaration. Python-specific configuration is handled by the `python = import('python')` statement later in the file.

This change aims to resolve the "ERROR: Tried to use unknown language 'python'" issue encountered during `meson setup`.